### PR TITLE
Bump docker version 

### DIFF
--- a/cloudbuild/branch-cloudbuild.yaml
+++ b/cloudbuild/branch-cloudbuild.yaml
@@ -21,12 +21,12 @@ steps:
 
 ### Build
   - id: "build image"
-    name: "gcr.io/cloud-builders/docker"
+    name: "gcr.io/cloud-builders/docker:24.0.6"
     args: ["build", "-t", "gcr.io/${PROJECT_ID}/${_SERVICE_NAME}", "."]
 
 ### Push
   - id: "push image"
-    name: "gcr.io/cloud-builders/docker"
+    name: "gcr.io/cloud-builders/docker:24.0.6"
     args: ["push", "gcr.io/${PROJECT_ID}/${_SERVICE_NAME}"]
 
 ### Deploy

--- a/cloudbuild/main-cloudbuild.yaml
+++ b/cloudbuild/main-cloudbuild.yaml
@@ -21,12 +21,12 @@ steps:
 
 ### Build
   - id: "build image"
-    name: "gcr.io/cloud-builders/docker"
+    name: "gcr.io/cloud-builders/docker:24.0.6"
     args: ["build", "-t", "gcr.io/${PROJECT_ID}/${_SERVICE_NAME}", "."]
 
 ### Push
   - id: "push image"
-    name: "gcr.io/cloud-builders/docker"
+    name: "gcr.io/cloud-builders/docker:24.0.6"
     args: ["push", "gcr.io/${PROJECT_ID}/${_SERVICE_NAME}"]
 
 ### Deploy


### PR DESCRIPTION
The previous version caused issues with image builds at a customer so we're bumping the template to use the latest version of Docker. The `latest` that was used previously was version 20. 